### PR TITLE
Created overview skeleton

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { hot } from 'react-hot-loader/root';
 import PropTypes from 'prop-types';
+import Overview from './components/overview/Overview';
 
 function App(props) {
   const { name } = props;
@@ -11,6 +12,7 @@ function App(props) {
         {` ${name}`}
       </h1>
       <div>Sup</div>
+      <Overview />
     </>
   );
 }

--- a/src/components/overview/DescriptionDetails.jsx
+++ b/src/components/overview/DescriptionDetails.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Price from './Price';
+
+export default function DescriptionDetails() {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        marginLeft: '8em',
+      }}
+    >
+      <p>Basketball Shoes</p>
+      <p>Air Minis 250</p>
+      <p>
+        This optimized air cushion pocket reduces impact but keeps a perfect
+        balance underfoot.
+      </p>
+      <Price price={140} salePrice={100} />
+      {/* <AddToCart /> */}
+    </div>
+  );
+}

--- a/src/components/overview/ImageGallery.jsx
+++ b/src/components/overview/ImageGallery.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+export default function ImageGallery() {
+  return (
+    <img
+      src="https://tracksmith-media.imgix.net/Spring22-Mens-Twilight-Tee-Denim.png?auto=format,compress&crop=faces&dpr=2&fit=crop&h=640&w=640"
+      width="400px"
+      alt="sample img"
+    />
+  );
+}

--- a/src/components/overview/Overview.jsx
+++ b/src/components/overview/Overview.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import ImageGallery from './ImageGallery';
+import DescriptionDetails from './DescriptionDetails';
+
+export default function Overview() {
+  return (
+    <section
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'center',
+        alignItems: 'center',
+        padding: '4em',
+      }}
+    >
+      <ImageGallery />
+      <DescriptionDetails />
+    </section>
+  );
+}

--- a/src/components/overview/Price.jsx
+++ b/src/components/overview/Price.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function Price({ price, salePrice }) {
+  // const showSalePrice = salePrice === 0;
+
+  return (
+    <span
+      style={{
+        display: 'flex',
+      }}
+    >
+      {salePrice === 0 ? (
+        <p>${price}</p>
+      ) : (
+        <>
+          <p
+            style={{
+              textDecoration: 'line-through',
+            }}
+          >
+            ${price}
+          </p>
+          <p>${salePrice}</p>
+        </>
+      )}
+    </span>
+  );
+}
+
+Price.propTypes = {
+  price: PropTypes.number.isRequired,
+  salePrice: PropTypes.number,
+};
+
+Price.defaultProps = {
+  salePrice: 0,
+};


### PR DESCRIPTION
Changes made:
- App.jsx
  - got rid of the 'sup' text inside of the start feature
  - Inserted `<Overview />` skeleton
- Overview.jsx:
  - Setup basic flex-box container to hold sample `<ImageGallery />` and `<DescriptionDetails />`
- ImageGallery.jsx: renders a placeholder image
- DescriptionDetails.jsx:
  - Filled with dummy category, title, and description
  - Contains `<Price />` component
- Price.jsx: accepts `price` and `salePrice` props. If `salePrice` exists, the original `price` is struck-through

How the page now looks:
![Screen Shot 2022-05-19 at 2 50 46 PM](https://user-images.githubusercontent.com/7807880/169410517-c8c547b4-a5ee-4f4a-9a1a-ae41e65b27ae.jpg)
