### PR TITLE
Create link to review section from overview

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -4,6 +4,10 @@
   box-sizing: border-box;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 /* Overview Styles Section */
 
 /* Question and Answers Section */

--- a/src/components/overview/DescriptionDetails.jsx
+++ b/src/components/overview/DescriptionDetails.jsx
@@ -19,7 +19,17 @@ export default function DescriptionDetails() {
         This optimized air cushion pocket reduces impact but keeps a perfect
         balance underfoot.
       </p>
-      <Stars rating={2.5} />
+      <span>
+        <Stars rating={2.5} />
+        <a
+          href="#ratings-reviews"
+          style={{
+            color: 'black',
+          }}
+        >
+          Read all [#] of reviews
+        </a>
+      </span>
       <Price price={140} salePrice={100} />
       <StyleSelector />
       <AddToCart />

--- a/src/components/ratings_reviews/RatingsAndReviews.jsx
+++ b/src/components/ratings_reviews/RatingsAndReviews.jsx
@@ -11,6 +11,7 @@ function RatingsAndReviews() {
         justifyContent: 'start',
         padding: '1em',
       }}
+      id="ratings-reviews"
     >
       <Ratings />
       <Reviews />


### PR DESCRIPTION
@RFP-Verde/verde created a link in the overview section that, when clicked, automatically scrolls the page down to the Ratings and Reviews section.
- Added an id tag to the ratings and reviews section
- Made a reference to ^ id tag via an anchor tag in the overview section
- Added smooth scrolling to the css file to ensure the page scrolls smoothly down to the section, as opposed to instantly teleporting down the page.