### PR TITLE
Implement functionality for style selector

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -31,6 +31,10 @@ html {
   transform: scale(1.02);
 }
 
+.style-thumbnail:hover {
+  cursor: pointer;
+}
+
 /*------- Question and Answers Section ------*/
 .qa-widget {
   display: flex;

--- a/dist/styles.css
+++ b/dist/styles.css
@@ -31,6 +31,16 @@ html {
   transform: scale(1.02);
 }
 
+.style-thumbnail {
+  border-radius: 50%;
+  border-color: transparent;
+  margin: 0;
+  margin-right: 1em;
+  padding: 0.25em;
+  border-width: 0;
+  display: flex;
+}
+
 .style-thumbnail:hover {
   cursor: pointer;
 }

--- a/src/components/overview/DescriptionDetails.jsx
+++ b/src/components/overview/DescriptionDetails.jsx
@@ -5,7 +5,14 @@ import StyleSelector from './StyleSelector';
 import Price from '../shared/Price';
 import Stars from '../shared/Stars';
 
-export default function DescriptionDetails({ category, name, description }) {
+export default function DescriptionDetails({
+  category,
+  name,
+  description,
+  styles,
+  currStyle,
+  setCurrStyle,
+}) {
   return (
     <div
       style={{
@@ -29,7 +36,11 @@ export default function DescriptionDetails({ category, name, description }) {
         </a>
       </span>
       <Price price={140} salePrice={100} />
-      <StyleSelector />
+      <StyleSelector
+        styles={styles}
+        currStyle={currStyle}
+        setCurrStyle={setCurrStyle}
+      />
       <AddToCart />
     </div>
   );
@@ -39,4 +50,13 @@ DescriptionDetails.propTypes = {
   category: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
+  styles: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.bool,
+    PropTypes.object,
+    PropTypes.array,
+  ]).isRequired,
+  currStyle: PropTypes.number.isRequired,
+  setCurrStyle: PropTypes.func.isRequired,
 };

--- a/src/components/overview/DescriptionDetails.jsx
+++ b/src/components/overview/DescriptionDetails.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import AddToCart from './AddToCart';
 import StyleSelector from './StyleSelector';
 import Price from '../shared/Price';
 import Stars from '../shared/Stars';
-import productData from './example_data/productData';
 
-export default function DescriptionDetails() {
+export default function DescriptionDetails({ category, name, description }) {
   return (
     <div
       style={{
@@ -14,9 +14,9 @@ export default function DescriptionDetails() {
         marginLeft: '8em',
       }}
     >
-      <p>{productData.category}</p>
-      <p>{productData.name}</p>
-      {productData.description.length && <p>{productData.description}</p>}
+      <p>{category}</p>
+      <p>{name}</p>
+      {description.length && <p>{description}</p>}
       <span>
         <Stars rating={2.5} />
         <a
@@ -34,3 +34,9 @@ export default function DescriptionDetails() {
     </div>
   );
 }
+
+DescriptionDetails.propTypes = {
+  category: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+};

--- a/src/components/overview/DescriptionDetails.jsx
+++ b/src/components/overview/DescriptionDetails.jsx
@@ -12,6 +12,8 @@ export default function DescriptionDetails({
   styles,
   currStyle,
   setCurrStyle,
+  currPrice,
+  currSalePrice,
 }) {
   return (
     <div
@@ -35,7 +37,7 @@ export default function DescriptionDetails({
           Read all [#] of reviews
         </a>
       </span>
-      <Price price={140} salePrice={100} />
+      <Price price={currPrice} salePrice={currSalePrice} />
       <StyleSelector
         styles={styles}
         currStyle={currStyle}
@@ -59,4 +61,6 @@ DescriptionDetails.propTypes = {
   ]).isRequired,
   currStyle: PropTypes.number.isRequired,
   setCurrStyle: PropTypes.func.isRequired,
+  currPrice: PropTypes.number.isRequired,
+  currSalePrice: PropTypes.number.isRequired,
 };

--- a/src/components/overview/ExpandedView.jsx
+++ b/src/components/overview/ExpandedView.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export default function ExpandedView({ changeImgView }) {
+export default function ExpandedView({ changeImgView, currPhotoUrl }) {
   return (
     <div
       style={{
@@ -12,7 +12,7 @@ export default function ExpandedView({ changeImgView }) {
       }}
     >
       <img
-        src="https://tracksmith-media.imgix.net/Spring22-Mens-Twilight-Tee-Denim.png?auto=format,compress&crop=faces&dpr=2&fit=crop&h=640&w=640"
+        src={currPhotoUrl}
         alt="sample img"
         style={{
           padding: '4em',
@@ -36,4 +36,5 @@ export default function ExpandedView({ changeImgView }) {
 
 ExpandedView.propTypes = {
   changeImgView: PropTypes.func.isRequired,
+  currPhotoUrl: PropTypes.string.isRequired,
 };

--- a/src/components/overview/ImageGallery.jsx
+++ b/src/components/overview/ImageGallery.jsx
@@ -1,19 +1,15 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Thumbnails from './Thumbnails';
-import productStylesData from './example_data/productStylesData';
 
-export default function ImageGallery({ changeImgView }) {
-  const [currImgIdx, setCurrImgIdx] = useState(0);
-
-  const incrementIdx = () => {
-    setCurrImgIdx((prev) => prev + 1);
-  };
-
-  const decrementIdx = () => {
-    setCurrImgIdx((prev) => prev - 1);
-  };
-
+export default function ImageGallery({
+  changeImgView,
+  photos,
+  currImgIdx,
+  incrementIdx,
+  decrementIdx,
+  setCurrImgIdx,
+}) {
   return (
     <section
       style={{
@@ -22,7 +18,7 @@ export default function ImageGallery({ changeImgView }) {
       }}
     >
       <Thumbnails
-        photos={productStylesData.results[0].photos}
+        photos={photos}
         currImgIdx={currImgIdx}
         setCurrImgIdx={setCurrImgIdx}
       />
@@ -45,7 +41,7 @@ export default function ImageGallery({ changeImgView }) {
           onClick={changeImgView}
         >
           <img
-            src={productStylesData.results[0].photos[currImgIdx].url}
+            src={photos[currImgIdx].url}
             alt="sample img"
             style={{
               maxHeight: '500px',
@@ -66,7 +62,7 @@ export default function ImageGallery({ changeImgView }) {
             Prev
           </button>
         )}
-        {currImgIdx !== productStylesData.results[0].photos.length - 1 && (
+        {currImgIdx !== photos.length - 1 && (
           <button
             type="button"
             onClick={incrementIdx}
@@ -86,4 +82,15 @@ export default function ImageGallery({ changeImgView }) {
 
 ImageGallery.propTypes = {
   changeImgView: PropTypes.func.isRequired,
+  currImgIdx: PropTypes.number.isRequired,
+  incrementIdx: PropTypes.func.isRequired,
+  decrementIdx: PropTypes.func.isRequired,
+  setCurrImgIdx: PropTypes.func.isRequired,
+  photos: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.bool,
+    PropTypes.object,
+    PropTypes.array,
+  ]).isRequired,
 };

--- a/src/components/overview/Overview.jsx
+++ b/src/components/overview/Overview.jsx
@@ -27,6 +27,13 @@ export default function Overview() {
     setIsDefaultImgView((prev) => !prev);
   };
 
+  const currPrice = productStylesData.results[currStyle].original_price;
+
+  const currSalePrice =
+    productStylesData.results[currStyle].sale_price === null
+      ? 0
+      : productStylesData.results[currStyle].sale_price;
+
   return isDefaultImgView ? (
     <section
       style={{
@@ -52,6 +59,8 @@ export default function Overview() {
         styles={styles}
         currStyle={currStyle}
         setCurrStyle={setCurrStyle}
+        currPrice={currPrice}
+        currSalePrice={currSalePrice}
       />
     </section>
   ) : (

--- a/src/components/overview/Overview.jsx
+++ b/src/components/overview/Overview.jsx
@@ -27,12 +27,12 @@ export default function Overview() {
     setIsDefaultImgView((prev) => !prev);
   };
 
-  const currPrice = productStylesData.results[currStyle].original_price;
+  const currPrice = Number(productStylesData.results[currStyle].original_price);
 
   const currSalePrice =
     productStylesData.results[currStyle].sale_price === null
       ? 0
-      : productStylesData.results[currStyle].sale_price;
+      : Number(productStylesData.results[currStyle].sale_price);
 
   return isDefaultImgView ? (
     <section

--- a/src/components/overview/Overview.jsx
+++ b/src/components/overview/Overview.jsx
@@ -8,6 +8,12 @@ import productData from './example_data/productData';
 export default function Overview() {
   const [isDefaultImgView, setIsDefaultImgView] = useState(true);
   const [currImgIdx, setCurrImgIdx] = useState(0);
+  const [currStyle, setCurrStyle] = useState(0);
+
+  const styles = productStylesData.results.map((style) => ({
+    styleId: style.style_id,
+    iconUrl: style.photos[0].thumbnail_url,
+  }));
 
   const incrementIdx = () => {
     setCurrImgIdx((prev) => prev + 1);
@@ -33,7 +39,7 @@ export default function Overview() {
     >
       <ImageGallery
         changeImgView={changeImgView}
-        photos={productStylesData.results[0].photos}
+        photos={productStylesData.results[currStyle].photos}
         currImgIdx={currImgIdx}
         incrementIdx={incrementIdx}
         decrementIdx={decrementIdx}
@@ -43,6 +49,9 @@ export default function Overview() {
         category={productData.category}
         name={productData.name}
         description={productData.description}
+        styles={styles}
+        currStyle={currStyle}
+        setCurrStyle={setCurrStyle}
       />
     </section>
   ) : (

--- a/src/components/overview/Overview.jsx
+++ b/src/components/overview/Overview.jsx
@@ -55,6 +55,9 @@ export default function Overview() {
       />
     </section>
   ) : (
-    <ExpandedView changeImgView={changeImgView} />
+    <ExpandedView
+      changeImgView={changeImgView}
+      currPhotoUrl={productStylesData.results[currStyle].photos[currImgIdx].url}
+    />
   );
 }

--- a/src/components/overview/Overview.jsx
+++ b/src/components/overview/Overview.jsx
@@ -2,9 +2,20 @@ import React, { useState } from 'react';
 import ImageGallery from './ImageGallery';
 import ExpandedView from './ExpandedView';
 import DescriptionDetails from './DescriptionDetails';
+import productStylesData from './example_data/productStylesData';
+import productData from './example_data/productData';
 
 export default function Overview() {
   const [isDefaultImgView, setIsDefaultImgView] = useState(true);
+  const [currImgIdx, setCurrImgIdx] = useState(0);
+
+  const incrementIdx = () => {
+    setCurrImgIdx((prev) => prev + 1);
+  };
+
+  const decrementIdx = () => {
+    setCurrImgIdx((prev) => prev - 1);
+  };
 
   const changeImgView = () => {
     setIsDefaultImgView((prev) => !prev);
@@ -20,8 +31,19 @@ export default function Overview() {
         padding: '4em',
       }}
     >
-      <ImageGallery changeImgView={changeImgView} />
-      <DescriptionDetails />
+      <ImageGallery
+        changeImgView={changeImgView}
+        photos={productStylesData.results[0].photos}
+        currImgIdx={currImgIdx}
+        incrementIdx={incrementIdx}
+        decrementIdx={decrementIdx}
+        setCurrImgIdx={setCurrImgIdx}
+      />
+      <DescriptionDetails
+        category={productData.category}
+        name={productData.name}
+        description={productData.description}
+      />
     </section>
   ) : (
     <ExpandedView changeImgView={changeImgView} />

--- a/src/components/overview/StyleSelector.jsx
+++ b/src/components/overview/StyleSelector.jsx
@@ -1,31 +1,35 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { nanoid } from 'nanoid';
 
-export default function StyleSelector() {
-  const [selectedStyle, setSelectedStyle] = React.useState('style1');
-  const styles = ['style1', 'style2', 'style3', 'style4', 'style5'];
-
-  const handleStyleClick = (style) => {
-    setSelectedStyle(style);
+export default function StyleSelector({ styles, currStyle, setCurrStyle }) {
+  const handleStyleClick = (idx) => {
+    setCurrStyle(idx);
   };
-  const thumbnails = styles.map((style) => (
+
+  const thumbnails = styles.map((style, i) => (
     <button
+      className="style-thumbnail"
       type="button"
       key={nanoid()}
-      id={style}
-      onClick={() => handleStyleClick(style)}
+      onClick={() => handleStyleClick(i)}
       style={{
-        backgroundColor: selectedStyle === style ? 'lightgrey' : 'transparent',
+        backgroundColor: currStyle === i ? 'lightgrey' : 'transparent',
         borderRadius: '50%',
         borderColor: 'transparent',
         marginRight: '1em',
-        padding: '0.5em',
+        padding: '0.25em',
       }}
     >
       <img
-        src="https://tracksmith-media.imgix.net/Spring22-Mens-Twilight-Tee-Denim.png?auto=format,compress&crop=faces&dpr=2&fit=crop&h=30&w=30"
-        alt={style}
-        width="30px"
+        src={style.iconUrl}
+        alt={style.styleId}
+        style={{
+          width: '30px',
+          height: '30px',
+          objectFit: 'cover',
+          borderRadius: '50%',
+        }}
       />
     </button>
   ));
@@ -40,3 +44,15 @@ export default function StyleSelector() {
     </section>
   );
 }
+
+StyleSelector.propTypes = {
+  styles: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.bool,
+    PropTypes.object,
+    PropTypes.array,
+  ]).isRequired,
+  currStyle: PropTypes.number.isRequired,
+  setCurrStyle: PropTypes.func.isRequired,
+};

--- a/src/components/overview/StyleSelector.jsx
+++ b/src/components/overview/StyleSelector.jsx
@@ -15,10 +15,6 @@ export default function StyleSelector({ styles, currStyle, setCurrStyle }) {
       onClick={() => handleStyleClick(i)}
       style={{
         backgroundColor: currStyle === i ? 'lightgrey' : 'transparent',
-        borderRadius: '50%',
-        borderColor: 'transparent',
-        marginRight: '1em',
-        padding: '0.25em',
       }}
     >
       <img
@@ -38,6 +34,7 @@ export default function StyleSelector({ styles, currStyle, setCurrStyle }) {
     <section
       style={{
         marginBottom: '1em',
+        display: 'flex',
       }}
     >
       {thumbnails}


### PR DESCRIPTION
Clicking on the style from the style selector should now:
- update price accordingly
- update corresponding thumbnail images in the main gallery for the selected style
- persist thumbnail index position in main gallery (if you had the 2nd thumbnail selected in the main gallery and then switched styles via the style selector, you should now see the 2nd thumbnail for the newly selected style)

Going into expanded image view and back to the main view should now allow for persistent style and thumbnail selection.