### PR TITLE
highlight search term in questions

### DIFF
--- a/src/components/questions_answers/QnA_Components/MoreQuestions.jsx
+++ b/src/components/questions_answers/QnA_Components/MoreQuestions.jsx
@@ -3,7 +3,7 @@ import { nanoid } from 'nanoid';
 import PropTypes from 'prop-types';
 import Question from './Question';
 
-export default function MoreQuestions({ questions }) {
+export default function MoreQuestions({ questions, searchInput }) {
   const [collapseQuestions, setCollapseQuestions] = useState(true);
   return (
     <div>
@@ -20,7 +20,11 @@ export default function MoreQuestions({ questions }) {
       ) : (
         <div>
           {questions.slice(4).map((question) => (
-            <Question question={question} key={nanoid()} />
+            <Question
+              question={question}
+              key={nanoid()}
+              searchInput={searchInput}
+            />
           ))}
           <button
             className="more-questions"
@@ -45,4 +49,9 @@ MoreQuestions.propTypes = {
     PropTypes.object,
     PropTypes.array,
   ]).isRequired,
+  searchInput: PropTypes.string,
+};
+
+MoreQuestions.defaultProps = {
+  searchInput: null,
 };

--- a/src/components/questions_answers/QnA_Components/Question.jsx
+++ b/src/components/questions_answers/QnA_Components/Question.jsx
@@ -5,9 +5,10 @@ import PropTypes from 'prop-types';
 import AnswerList from './AnswerList';
 import MoreAnswers from './MoreAnswers';
 import AddAnswer from './AddAnswer';
+import SearchHighlight from './SearchHighlight';
 import config from '../../../../config/config';
 
-export default function Question({ question }) {
+export default function Question({ question, searchInput }) {
   const [marked, setMarked] = useState(false);
   const [helpful, setHelpful] = useState(question.question_helpfulness);
   const [showModal, setShowModal] = useState(false);
@@ -45,7 +46,15 @@ export default function Question({ question }) {
   return (
     <div className="question">
       <div className="question-body">
-        Q: {question.question_body}
+        Q:{' '}
+        {searchInput !== null ? (
+          <SearchHighlight
+            searchInput={searchInput}
+            body={question.question_body}
+          />
+        ) : (
+          question.question_body
+        )}
         <div className="question-control">
           Helpful?&nbsp;&nbsp;
           {marked === false && (
@@ -102,4 +111,9 @@ Question.propTypes = {
     PropTypes.object,
     PropTypes.array,
   ]).isRequired,
+  searchInput: PropTypes.string,
+};
+
+Question.defaultProps = {
+  searchInput: null,
 };

--- a/src/components/questions_answers/QnA_Components/QuestionList.jsx
+++ b/src/components/questions_answers/QnA_Components/QuestionList.jsx
@@ -20,12 +20,17 @@ export default function QuestionList({ questions, searchInput, productID }) {
             .slice(0, 5)
             .map((question, count) =>
               count > 3 ? (
-                <MoreQuestions questions={questions} key={nanoid()} />
+                <MoreQuestions
+                  questions={questions}
+                  key={nanoid()}
+                  searchInput={searchInput}
+                />
               ) : (
                 <Question
                   question={question}
                   key={nanoid()}
                   productID={productID}
+                  searchInput={searchInput}
                 />
               )
             )
@@ -36,12 +41,17 @@ export default function QuestionList({ questions, searchInput, productID }) {
             .slice(0, 5)
             .map((question, count) =>
               count > 3 ? (
-                <MoreQuestions questions={questions} key={nanoid()} />
+                <MoreQuestions
+                  questions={questions}
+                  key={nanoid()}
+                  searchInput={searchInput}
+                />
               ) : (
                 <Question
                   question={question}
                   productID={productID}
                   key={nanoid()}
+                  searchInput={searchInput}
                 />
               )
             )}

--- a/src/components/questions_answers/QnA_Components/SearchHighlight.jsx
+++ b/src/components/questions_answers/QnA_Components/SearchHighlight.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default function SearchHighlight({ searchInput, body }) {
+  const searchQuery = searchInput.toLowerCase();
+  const questionBody = body.toLowerCase();
+  const highlight = body.substring(
+    questionBody.indexOf(searchQuery),
+    questionBody.indexOf(searchQuery) + searchInput.length
+  );
+
+  return (
+    <span>
+      {body.substring(0, questionBody.indexOf(searchQuery))}
+      <mark>{highlight}</mark>
+      {body.substring(questionBody.indexOf(searchQuery) + searchInput.length)}
+    </span>
+  );
+}
+
+SearchHighlight.propTypes = {
+  searchInput: PropTypes.string.isRequired,
+  body: PropTypes.string.isRequired,
+};


### PR DESCRIPTION
hi @r-snow @arangotang @kennytran95 
I finished the first enhancement, quote from the business requirements : "any matching text within the questions should be highlighted as the search term changes and the list is filtered down. The text should appear in the normal black font, surrounded by a yellow highlight. This should only occur after 3 characters are entered, and the list results have been updated."
Please take a look when you have time, thanks!