### PR TITLE
Expanded view is now fully functional

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -44,6 +44,10 @@ html {
   cursor: pointer;
 }
 
+.expanded-view--img:hover {
+  cursor: crosshair;
+}
+
 .svg-inline--fa {
   transition: 0.3s;
 }

--- a/dist/styles.css
+++ b/dist/styles.css
@@ -44,6 +44,13 @@ html {
   cursor: pointer;
 }
 
+.svg-inline--fa {
+  transition: 0.3s;
+}
+
+.svg-inline--fa:hover {
+  transform: scale(1.1);
+}
 /*------- Question and Answers Section ------*/
 .qa-widget {
   display: flex;

--- a/dist/styles.css
+++ b/dist/styles.css
@@ -44,8 +44,12 @@ html {
   cursor: pointer;
 }
 
-.expanded-view--img:hover {
+.expanded-view--standard:hover {
   cursor: crosshair;
+}
+
+.expanded-view--zoomed:hover {
+  cursor: zoom-out;
 }
 
 .svg-inline--fa {

--- a/src/components/overview/DescriptionDetails.jsx
+++ b/src/components/overview/DescriptionDetails.jsx
@@ -17,6 +17,7 @@ export default function DescriptionDetails({
   reviewCount,
   avgRating,
   skuData,
+  slogan,
 }) {
   return (
     <div
@@ -29,6 +30,7 @@ export default function DescriptionDetails({
     >
       <p>{category}</p>
       <p>{name}</p>
+      {slogan.length && <b>{slogan}</b>}
       {description.length && (
         <p
           style={{
@@ -66,6 +68,7 @@ DescriptionDetails.propTypes = {
   category: PropTypes.string.isRequired,
   name: PropTypes.string.isRequired,
   description: PropTypes.string.isRequired,
+  slogan: PropTypes.string.isRequired,
   styles: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.number,

--- a/src/components/overview/ExpandedIcons.jsx
+++ b/src/components/overview/ExpandedIcons.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import {
+  faCircle,
+  faCaretRight,
+  faCaretLeft,
+} from '@fortawesome/free-solid-svg-icons';
+
+import { nanoid } from 'nanoid';
+
+export default function ExpandedIcons({ photos, currImgIdx, setCurrImgIdx }) {
+  const iconElements = photos.map((photo, i) => (
+    <FontAwesomeIcon
+      icon={faCircle}
+      size="2xs"
+      color="black"
+      style={{
+        opacity: currImgIdx === i ? '1' : '0.5',
+      }}
+      key={nanoid()}
+      type="button"
+      onClick={() => setCurrImgIdx(i)}
+    />
+  ));
+
+  const displayedIconElements = iconElements.filter((element, i) => {
+    if (currImgIdx <= 6 && i <= 6) {
+      return true;
+    }
+    if (currImgIdx > 6 && i >= currImgIdx - 6 && i <= currImgIdx) {
+      return true;
+    }
+    return false;
+  });
+
+  return (
+    <section
+      style={{
+        display: 'flex',
+        flexDirection: 'row',
+        gap: '1em',
+        alignItems: 'center',
+      }}
+    >
+      {currImgIdx !== 0 && (
+        <FontAwesomeIcon
+          icon={faCaretLeft}
+          size="xs"
+          color="black"
+          style={{
+            opacity: '0.5',
+          }}
+          onClick={() => {
+            setCurrImgIdx((prev) => prev - 1);
+          }}
+        />
+      )}
+      {displayedIconElements}
+      {currImgIdx !== photos.length - 1 && (
+        <FontAwesomeIcon
+          icon={faCaretRight}
+          size="xs"
+          color="black"
+          style={{
+            opacity: '0.5',
+          }}
+          onClick={() => {
+            setCurrImgIdx((prev) => prev + 1);
+          }}
+        />
+      )}
+    </section>
+  );
+}
+
+ExpandedIcons.propTypes = {
+  photos: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.bool,
+    PropTypes.object,
+    PropTypes.array,
+  ]).isRequired,
+  currImgIdx: PropTypes.number.isRequired,
+  setCurrImgIdx: PropTypes.func.isRequired,
+};

--- a/src/components/overview/ExpandedIcons.jsx
+++ b/src/components/overview/ExpandedIcons.jsx
@@ -41,6 +41,8 @@ export default function ExpandedIcons({ photos, currImgIdx, setCurrImgIdx }) {
         flexDirection: 'row',
         gap: '1em',
         alignItems: 'center',
+        position: 'absolute',
+        bottom: '2em',
       }}
     >
       {currImgIdx !== 0 && (

--- a/src/components/overview/ExpandedIcons.jsx
+++ b/src/components/overview/ExpandedIcons.jsx
@@ -13,7 +13,7 @@ export default function ExpandedIcons({ photos, currImgIdx, setCurrImgIdx }) {
   const iconElements = photos.map((photo, i) => (
     <FontAwesomeIcon
       icon={faCircle}
-      size="2xs"
+      size="lg"
       color="black"
       style={{
         opacity: currImgIdx === i ? '1' : '0.5',
@@ -48,7 +48,7 @@ export default function ExpandedIcons({ photos, currImgIdx, setCurrImgIdx }) {
       {currImgIdx !== 0 && (
         <FontAwesomeIcon
           icon={faCaretLeft}
-          size="xs"
+          size="lg"
           color="black"
           style={{
             opacity: '0.5',
@@ -62,7 +62,7 @@ export default function ExpandedIcons({ photos, currImgIdx, setCurrImgIdx }) {
       {currImgIdx !== photos.length - 1 && (
         <FontAwesomeIcon
           icon={faCaretRight}
-          size="xs"
+          size="lg"
           color="black"
           style={{
             opacity: '0.5',

--- a/src/components/overview/ExpandedView.jsx
+++ b/src/components/overview/ExpandedView.jsx
@@ -12,79 +12,115 @@ export default function ExpandedView({
   currImgIdx,
 }) {
   const [isZoomed, setIsZoomed] = useState(false);
+  const [x, setX] = useState('0');
+  const [y, setY] = useState('0');
 
   const handleImageClick = () => {
     setIsZoomed((prev) => !prev);
   };
 
-  const handleMouseEnter = (e) => {
-    if (isZoomed) {
-      console.log('onMouseEnter', e.clientX, e.clientY);
-    }
-  };
-
   const handleMouseMove = (e) => {
     if (isZoomed) {
-      console.log('onMouseMove', e.nativeEvent.clientX, e.nativeEvent.clientY);
-    }
-  };
-
-  const handleMouseLeave = (e) => {
-    if (isZoomed) {
-      console.log('onMouseLeave', e.clientX, e.clientY);
+      // console.log('onMouseMove', e.nativeEvent.clientX, e.nativeEvent.clientY);
+      setX(`${(0.5 * window.innerWidth - e.nativeEvent.clientX).toString()}`);
+      setY(`${(0.5 * window.innerHeight - e.nativeEvent.clientY).toString()}`);
     }
   };
 
   return (
-    <div
+    <section
+      id="expanded"
       style={{
         display: 'flex',
-        flexDirection: 'column',
         alignItems: 'center',
-        position: 'relative',
-        // padding: '0 2em',
+        justifyContent: 'center',
       }}
     >
-      <button
-        type="button"
+      <div
         style={{
-          backgroundColor: 'transparent',
-          borderColor: 'transparent',
-          objectFit: 'cover',
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          position: 'relative',
+          height: '100vh',
+          width: '100vw',
+          justifyContent: 'center',
+          // padding: '0 2em',
         }}
-        onClick={handleImageClick}
       >
-        <img
-          src={currPhotoUrl}
-          className="expanded-view--img"
-          alt="big img"
+        {!isZoomed ? (
+          <button
+            type="button"
+            style={{
+              backgroundColor: 'transparent',
+              borderColor: 'transparent',
+              objectFit: 'cover',
+              margin: '0',
+              padding: '0',
+            }}
+            onClick={handleImageClick}
+          >
+            <img
+              src={currPhotoUrl}
+              className="expanded-view--standard"
+              alt="big img"
+              style={{
+                // transform: 'scale(2.5)',
+                // padding: '4em',
+                maxHeight: '80vh',
+                maxWidth: '60vw',
+                minWidth: '0',
+              }}
+            />
+          </button>
+        ) : (
+          <button
+            type="button"
+            style={{
+              backgroundColor: 'transparent',
+              borderColor: 'transparent',
+              margin: '0',
+              padding: '0',
+              height: '100vh',
+              width: '100vw',
+              display: 'block',
+              overflow: 'hidden',
+            }}
+            onClick={handleImageClick}
+          >
+            <img
+              src={currPhotoUrl}
+              className="expanded-view--zoomed"
+              alt="big img"
+              style={{
+                transform: `scale(2.5)`,
+                height: '500px',
+                position: 'relative',
+                top: `${y}px`,
+                left: `${x}px`,
+                verticalAlign: 'top',
+              }}
+              onMouseMove={handleMouseMove}
+            />
+          </button>
+        )}
+        <FontAwesomeIcon
+          icon={faCompress}
+          type="button"
+          onClick={changeImgView}
           style={{
-            // transform: 'scale(2.5)',
-            padding: '4em',
-            maxHeight: '80vh',
-            minWidth: '0',
+            position: 'absolute',
+            top: '1em',
+            right: '1em',
           }}
-          onMouseEnter={handleMouseEnter}
-          onMouseMove={handleMouseMove}
-          onMouseLeave={handleMouseLeave}
         />
-      </button>
-      <FontAwesomeIcon
-        icon={faCompress}
-        type="button"
-        onClick={changeImgView}
-        style={{
-          position: 'absolute',
-          top: '1em',
-          right: '1em',
-        }}
-      />
-      <ExpandedIcons
-        photos={photos}
-        currImgIdx={currImgIdx}
-        setCurrImgIdx={setCurrImgIdx}
-      />
-    </div>
+        <ExpandedIcons
+          photos={photos}
+          currImgIdx={currImgIdx}
+          setCurrImgIdx={setCurrImgIdx}
+        />
+      </div>
+    </section>
   );
 }
 

--- a/src/components/overview/ExpandedView.jsx
+++ b/src/components/overview/ExpandedView.jsx
@@ -1,7 +1,11 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCompress } from '@fortawesome/free-solid-svg-icons';
+import {
+  faCompress,
+  faAngleRight,
+  faAngleLeft,
+} from '@fortawesome/free-solid-svg-icons';
 import ExpandedIcons from './ExpandedIcons';
 
 export default function ExpandedView({
@@ -21,7 +25,6 @@ export default function ExpandedView({
 
   const handleMouseMove = (e) => {
     if (isZoomed) {
-      // console.log('onMouseMove', e.nativeEvent.clientX, e.nativeEvent.clientY);
       setX(`${(0.5 * window.innerWidth - e.nativeEvent.clientX).toString()}`);
       setY(`${(0.5 * window.innerHeight - e.nativeEvent.clientY).toString()}`);
     }
@@ -36,6 +39,40 @@ export default function ExpandedView({
         justifyContent: 'center',
       }}
     >
+      {currImgIdx !== 0 && !isZoomed && (
+        <FontAwesomeIcon
+          icon={faAngleLeft}
+          type="button"
+          color="black"
+          size="lg"
+          style={{
+            position: 'absolute',
+            top: '50%',
+            left: '1em',
+            zIndex: '9999',
+          }}
+          onClick={() => {
+            setCurrImgIdx((prev) => prev - 1);
+          }}
+        />
+      )}
+      {currImgIdx !== photos.length - 1 && !isZoomed && (
+        <FontAwesomeIcon
+          icon={faAngleRight}
+          type="button"
+          color="black"
+          size="lg"
+          style={{
+            position: 'absolute',
+            top: '50%',
+            right: '1em',
+            zIndex: '9999',
+          }}
+          onClick={() => {
+            setCurrImgIdx((prev) => prev + 1);
+          }}
+        />
+      )}
       <div
         style={{
           display: 'flex',
@@ -45,7 +82,6 @@ export default function ExpandedView({
           height: '100vh',
           width: '100vw',
           justifyContent: 'center',
-          // padding: '0 2em',
         }}
       >
         {!isZoomed ? (
@@ -65,8 +101,6 @@ export default function ExpandedView({
               className="expanded-view--standard"
               alt="big img"
               style={{
-                // transform: 'scale(2.5)',
-                // padding: '4em',
                 maxHeight: '80vh',
                 maxWidth: '60vw',
                 minWidth: '0',
@@ -104,21 +138,26 @@ export default function ExpandedView({
             />
           </button>
         )}
-        <FontAwesomeIcon
-          icon={faCompress}
-          type="button"
-          onClick={changeImgView}
-          style={{
-            position: 'absolute',
-            top: '1em',
-            right: '1em',
-          }}
-        />
-        <ExpandedIcons
-          photos={photos}
-          currImgIdx={currImgIdx}
-          setCurrImgIdx={setCurrImgIdx}
-        />
+        {!isZoomed && (
+          <FontAwesomeIcon
+            icon={faCompress}
+            type="button"
+            size="lg"
+            onClick={changeImgView}
+            style={{
+              position: 'absolute',
+              top: '1em',
+              right: '1em',
+            }}
+          />
+        )}
+        {!isZoomed && (
+          <ExpandedIcons
+            photos={photos}
+            currImgIdx={currImgIdx}
+            setCurrImgIdx={setCurrImgIdx}
+          />
+        )}
       </div>
     </section>
   );

--- a/src/components/overview/ExpandedView.jsx
+++ b/src/components/overview/ExpandedView.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCompress } from '@fortawesome/free-solid-svg-icons';
 import ExpandedIcons from './ExpandedIcons';
 
 export default function ExpandedView({
@@ -28,7 +30,8 @@ export default function ExpandedView({
           minWidth: '0',
         }}
       />
-      <button
+      <FontAwesomeIcon
+        icon={faCompress}
         type="button"
         onClick={changeImgView}
         style={{
@@ -36,9 +39,7 @@ export default function ExpandedView({
           top: '1em',
           right: '1em',
         }}
-      >
-        Main View
-      </button>
+      />
       <ExpandedIcons
         photos={photos}
         currImgIdx={currImgIdx}

--- a/src/components/overview/ExpandedView.jsx
+++ b/src/components/overview/ExpandedView.jsx
@@ -1,7 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ExpandedIcons from './ExpandedIcons';
 
-export default function ExpandedView({ changeImgView, currPhotoUrl }) {
+export default function ExpandedView({
+  changeImgView,
+  currPhotoUrl,
+  photos,
+  setCurrImgIdx,
+  currImgIdx,
+}) {
   return (
     <div
       style={{
@@ -9,14 +16,16 @@ export default function ExpandedView({ changeImgView, currPhotoUrl }) {
         flexDirection: 'column',
         alignItems: 'center',
         position: 'relative',
+        // padding: '0 2em',
       }}
     >
       <img
         src={currPhotoUrl}
-        alt="sample img"
+        alt="big img"
         style={{
           padding: '4em',
-          maxWidth: '50%',
+          maxHeight: '80vh',
+          minWidth: '0',
         }}
       />
       <button
@@ -30,11 +39,25 @@ export default function ExpandedView({ changeImgView, currPhotoUrl }) {
       >
         Main View
       </button>
+      <ExpandedIcons
+        photos={photos}
+        currImgIdx={currImgIdx}
+        setCurrImgIdx={setCurrImgIdx}
+      />
     </div>
   );
 }
 
 ExpandedView.propTypes = {
   changeImgView: PropTypes.func.isRequired,
+  setCurrImgIdx: PropTypes.func.isRequired,
   currPhotoUrl: PropTypes.string.isRequired,
+  currImgIdx: PropTypes.number.isRequired,
+  photos: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.number,
+    PropTypes.bool,
+    PropTypes.object,
+    PropTypes.array,
+  ]).isRequired,
 };

--- a/src/components/overview/ExpandedView.jsx
+++ b/src/components/overview/ExpandedView.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCompress } from '@fortawesome/free-solid-svg-icons';
@@ -11,6 +11,30 @@ export default function ExpandedView({
   setCurrImgIdx,
   currImgIdx,
 }) {
+  const [isZoomed, setIsZoomed] = useState(false);
+
+  const handleImageClick = () => {
+    setIsZoomed((prev) => !prev);
+  };
+
+  const handleMouseEnter = (e) => {
+    if (isZoomed) {
+      console.log('onMouseEnter', e.clientX, e.clientY);
+    }
+  };
+
+  const handleMouseMove = (e) => {
+    if (isZoomed) {
+      console.log('onMouseMove', e.nativeEvent.clientX, e.nativeEvent.clientY);
+    }
+  };
+
+  const handleMouseLeave = (e) => {
+    if (isZoomed) {
+      console.log('onMouseLeave', e.clientX, e.clientY);
+    }
+  };
+
   return (
     <div
       style={{
@@ -21,15 +45,30 @@ export default function ExpandedView({
         // padding: '0 2em',
       }}
     >
-      <img
-        src={currPhotoUrl}
-        alt="big img"
+      <button
+        type="button"
         style={{
-          padding: '4em',
-          maxHeight: '80vh',
-          minWidth: '0',
+          backgroundColor: 'transparent',
+          borderColor: 'transparent',
+          objectFit: 'cover',
         }}
-      />
+        onClick={handleImageClick}
+      >
+        <img
+          src={currPhotoUrl}
+          className="expanded-view--img"
+          alt="big img"
+          style={{
+            // transform: 'scale(2.5)',
+            padding: '4em',
+            maxHeight: '80vh',
+            minWidth: '0',
+          }}
+          onMouseEnter={handleMouseEnter}
+          onMouseMove={handleMouseMove}
+          onMouseLeave={handleMouseLeave}
+        />
+      </button>
       <FontAwesomeIcon
         icon={faCompress}
         type="button"

--- a/src/components/overview/ImageGallery.jsx
+++ b/src/components/overview/ImageGallery.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faAngleRight, faAngleLeft } from '@fortawesome/free-solid-svg-icons';
 import Thumbnails from './Thumbnails';
 
 export default function ImageGallery({
@@ -50,30 +52,30 @@ export default function ImageGallery({
           />
         </button>
         {currImgIdx !== 0 && (
-          <button
+          <FontAwesomeIcon
+            icon={faAngleLeft}
             type="button"
             onClick={decrementIdx}
+            color="black"
             style={{
               position: 'absolute',
               top: '50%',
               left: '1em',
             }}
-          >
-            Prev
-          </button>
+          />
         )}
         {currImgIdx !== photos.length - 1 && (
-          <button
+          <FontAwesomeIcon
+            icon={faAngleRight}
             type="button"
             onClick={incrementIdx}
+            color="black"
             style={{
               position: 'absolute',
               top: '50%',
               right: '1em',
             }}
-          >
-            Next
-          </button>
+          />
         )}
       </div>
     </section>

--- a/src/components/overview/ImageGallery.jsx
+++ b/src/components/overview/ImageGallery.jsx
@@ -33,24 +33,26 @@ export default function ImageGallery({
           justifyContent: 'center',
         }}
       >
-        <button
-          type="button"
-          className="main-image-btn"
-          style={{
-            backgroundColor: 'transparent',
-            borderColor: 'transparent',
-          }}
-          onClick={changeImgView}
-        >
-          <img
-            src={photos[currImgIdx].url}
-            alt="sample img"
+        <a href="#expanded">
+          <button
+            type="button"
+            className="main-image-btn"
             style={{
-              maxHeight: '500px',
-              maxWidth: '390px',
+              backgroundColor: 'transparent',
+              borderColor: 'transparent',
             }}
-          />
-        </button>
+            onClick={changeImgView}
+          >
+            <img
+              src={photos[currImgIdx].url}
+              alt="sample img"
+              style={{
+                maxHeight: '500px',
+                maxWidth: '390px',
+              }}
+            />
+          </button>
+        </a>
         {currImgIdx !== 0 && (
           <FontAwesomeIcon
             icon={faAngleLeft}

--- a/src/components/overview/Overview.jsx
+++ b/src/components/overview/Overview.jsx
@@ -85,6 +85,7 @@ export default function Overview() {
         category={productData.category}
         name={productData.name}
         description={productData.description}
+        slogan={productData.slogan}
         styles={styles}
         currStyle={currStyle}
         setCurrStyle={setCurrStyle}

--- a/src/components/overview/Overview.jsx
+++ b/src/components/overview/Overview.jsx
@@ -53,7 +53,14 @@ export default function Overview() {
   };
 
   const changeImgView = () => {
-    setIsDefaultImgView((prev) => !prev);
+    setIsDefaultImgView((prev) => {
+      if (prev) {
+        document.body.style.overflow = 'hidden';
+      } else {
+        document.body.style.overflow = 'initial';
+      }
+      return !prev;
+    });
   };
 
   const currPrice = Number(productStylesData.results[currStyle].original_price);

--- a/src/components/overview/Overview.jsx
+++ b/src/components/overview/Overview.jsx
@@ -99,6 +99,9 @@ export default function Overview() {
     <ExpandedView
       changeImgView={changeImgView}
       currPhotoUrl={productStylesData.results[currStyle].photos[currImgIdx].url}
+      photos={productStylesData.results[currStyle].photos}
+      currImgIdx={currImgIdx}
+      setCurrImgIdx={setCurrImgIdx}
     />
   );
 }

--- a/src/components/overview/Thumbnails.jsx
+++ b/src/components/overview/Thumbnails.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { nanoid } from 'nanoid';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faAngleUp, faAngleDown } from '@fortawesome/free-solid-svg-icons';
 
 export default function Thumbnails({ photos, currImgIdx, setCurrImgIdx }) {
   const thumbnailElements = photos.map((photo, i) => (
@@ -41,25 +43,25 @@ export default function Thumbnails({ photos, currImgIdx, setCurrImgIdx }) {
       }}
     >
       {currImgIdx !== 0 && (
-        <button
+        <FontAwesomeIcon
+          icon={faAngleUp}
+          color="black"
           type="button"
           onClick={() => {
             setCurrImgIdx((prev) => prev - 1);
           }}
-        >
-          Up
-        </button>
+        />
       )}
       {displayedThumbnailElements}
       {currImgIdx !== photos.length - 1 && (
-        <button
+        <FontAwesomeIcon
+          icon={faAngleDown}
+          color="black"
           type="button"
           onClick={() => {
             setCurrImgIdx((prev) => prev + 1);
           }}
-        >
-          Down
-        </button>
+        />
       )}
     </section>
   );


### PR DESCRIPTION
Clicking on the image in the main gallery should now take you to a full-screen expanded view

New icons:
- Click the arrows on the left and right hand sides of the screen to move from one picture to the next
  - If on the "edge" of the list of images, only the corresponding arrow will show
- Exit via the icon in the top-right corner
- Icons at the bottom allow you to either:
  - scroll through images one-by-one by clicking the carats
  - jump to any image by clicking on an icon
  - icon for currently selected image renders darker than the rest

Clicking on the image while in expanded view takes you to the _**Zoom View!**_:
- Image is magnified to 2.5x its original size
- Moving your cursor allows you to inspect different areas of the image
- Icons are hidden in this view
- Leave the view by clicking on the image