### PR TITLE
connect overview component to related items component

### DIFF
--- a/dist/styles.css
+++ b/dist/styles.css
@@ -41,6 +41,8 @@ body {
 
 #app {
   background-color: #f8f8ff;
+  display: flex;
+  flex-direction: column;
 }
 
 .fade-in {
@@ -136,7 +138,7 @@ body {
 #top {
   position: relative;
   background-color: rgb(144, 169, 139);
-  padding: 8px 12px;
+  padding: 10px 24px;
   margin-bottom: 36px;
   display: flex;
   align-items: center;
@@ -294,6 +296,14 @@ body {
   align-items: center;
   flex-wrap: wrap;
   max-width: 100vw;
+}
+
+.horizontal-divider {
+  width: 80%;
+  height: 1px;
+  margin: 30px;
+  background-color: lightgrey;
+  align-self: center;
 }
 
 .main-image-btn:hover {
@@ -888,7 +898,7 @@ body {
   font-weight: 500;
   font-size: 36px;
   margin-bottom: 0;
-  margin-top: 50px;
+  margin-top: 0;
 }
 
 .carousel {
@@ -1022,7 +1032,7 @@ body {
   font-weight: 500;
   font-size: 36px;
   margin-bottom: 0;
-  margin-top: 50px;
+  margin-top: 0;
 }
 
 .your-outfit {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import YourOutfit from './components/related_items_outfit/YourOutfit';
 import currentProduct from './components/related_items_outfit/sampleProductData';
 
 function App() {
+  // const [productID, setProductID] = useState(40344);
   const [curProd, setCurProd] = useState(currentProduct);
   const [localCart, setLocalCart] = useState(
     JSON.parse(localStorage.getItem('localCart')) || []
@@ -53,8 +54,14 @@ function App() {
         setShowDrawer={setShowDrawer}
         deleteCartItem={deleteCartItem}
       />
-      <Overview setLocalCart={setLocalCart} setShowDrawer={setShowDrawer} />
+      <Overview
+        setLocalCart={setLocalCart}
+        setShowDrawer={setShowDrawer}
+        productID={curProd.id}
+      />
+      <div className="horizontal-divider"> </div>
       <RelatedItems curProd={curProd} setCurProd={setCurProd} />
+      <div className="horizontal-divider"> </div>
       <YourOutfit curProd={curProd} />
       <QnA />
       <RatingsAndReviews />

--- a/src/components/overview/Overview.jsx
+++ b/src/components/overview/Overview.jsx
@@ -9,7 +9,7 @@ import sampleProductStylesData from './example_data/productStylesData';
 import sampleProductReviewsData from './example_data/productReviewsData';
 import config from '../../../config/config';
 
-export default function Overview({ setLocalCart, setShowDrawer }) {
+export default function Overview({ setLocalCart, setShowDrawer, productID }) {
   const [isDefaultImgView, setIsDefaultImgView] = useState(true);
   const [currImgIdx, setCurrImgIdx] = useState(0);
   const [currStyle, setCurrStyle] = useState(0);
@@ -19,7 +19,6 @@ export default function Overview({ setLocalCart, setShowDrawer }) {
       size: 'Select Size...',
     },
   });
-  const [productID, setProductID] = useState(40344);
   const [productData, setProductData] = useState(sampleProductData);
   const [productStylesData, setProductStylesData] = useState(
     sampleProductStylesData
@@ -176,4 +175,5 @@ export default function Overview({ setLocalCart, setShowDrawer }) {
 Overview.propTypes = {
   setLocalCart: PropTypes.func.isRequired,
   setShowDrawer: PropTypes.func.isRequired,
+  productID: PropTypes.number.isRequired,
 };


### PR DESCRIPTION
Product ID is now dictated by the related items component, so you should now be able to switch across products by clicking on one of the product cards in the related items section